### PR TITLE
fix #11: add iframe-test page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 This repo contains the code behind <https://trackertest.org>.
 
 <https://itisatracker.org> and <https://itisatracker.com> are aliases which also point here.
+
+## Run locally
+
+An easy way to run this locally:
+
+```
+python -m SimpleHTTPServer
+```

--- a/iframe-test.html
+++ b/iframe-test.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+
+  <title>Tracker iframe test</title>
+  
+</head>
+<body>
+<h1>Tracker iframe test</h1>
+<ul>
+  <li>When a user visits a tracking site that includes an iframe to a 3rd-party,</li>
+  <li>and that 3rd-party iframe makes a request back to the 1st-party site in the parent frame
+    <ul>
+      <li>we should allow the request to mitigate breakage,
+        <ul>
+          <li>since the 1st-party already knows the user is on the 3rd-party site by virtue of the iframe.</li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>
+<p>E.g., facebook games, etc.</p>
+
+<h2>You are on <span id="current-domain"></span>.</h2>
+<p id="operation"></p>
+<iframe id="the-iframe"></iframe>
+<h3>Check dev toolbox for security and/or error message.</h3>
+<script src="iframe-test.js"></script>
+</body>
+</html>

--- a/iframe-test.js
+++ b/iframe-test.js
@@ -1,0 +1,17 @@
+const isTopWindow = window.self === window.top;
+const locURL = new URL(window.location);
+const operationElement = document.querySelector('#operation');
+const iFrameSrc = 'http://trackertest.org:8000/iframe-test.html';
+const scriptSrc = 'http://itisatracker.com:8000/tracker.js';
+
+document.querySelector('#current-domain').innerHTML = locURL.hostname;
+
+if (isTopWindow && locURL.hostname == 'itisatracker.com' ) {
+  operationElement.innerHTML = 'Setting iframe src to: ' + iFrameSrc; 
+  document.querySelector('#the-iframe').src = iFrameSrc;
+} else if (!isTopWindow && locURL.hostname == 'trackertest.org') {
+  operationElement.innerHTML = 'Writing script tag with src to: ' + scriptSrc; 
+  document.write('<scr' + 'ipt src="' + scriptSrc + '"></sc' + 'ript>');
+} else {
+  operationElement.innerHTML = "Unknown case. Expected itisatracker.com to be the top window URL hostname.";
+}


### PR DESCRIPTION
I tried to test this locally ... the regular (i.e., non-PBM w/ TP) window looks fine:

![tracker-iframe-test-regular](https://cloud.githubusercontent.com/assets/71928/16772429/da0551e4-4819-11e6-9635-14dc80a71ba2.png)

But the PBM w/TP window blocks even the first iframe load?

![tracker-iframe-test-tp](https://cloud.githubusercontent.com/assets/71928/16772461/f12538a8-4819-11e6-916f-e5ed6e55e327.png)

Did I misunderstand our TP implementation? Are we intentionally blocking `<iframe src="http://trackertest.org"></iframe>` loads from itisatracker.com ?
