### PR TITLE
Set SameSite=None for cross-site cookie.

### DIFF
--- a/storage_access_api.html
+++ b/storage_access_api.html
@@ -23,7 +23,7 @@
           var randVal = Math.random();
           var set = document.getElementById('cookie_set');
           set.innerHTML = randVal;
-          document.cookie = 'testPageCookie='+randVal;
+          document.cookie = 'testPageCookie='+randVal+'; SameSite=None';
 
           // Get a cookie
           var get = document.getElementById('cookie_read');


### PR DESCRIPTION
Different browsers have different default behaviors when SameSite is unspecified, so this change makes the behavior more consistent across browsers.